### PR TITLE
Note global controllers removed in angular 1.3.0

### DIFF
--- a/tutorial/03-setup-scopes.md
+++ b/tutorial/03-setup-scopes.md
@@ -63,6 +63,8 @@ We'll explain what `{{title}}` and `ng-model="title"` is in a minute.
 
 See how the function name is the same as the `ng-controller's` value?  Angular will be looking for a function with this name in our JavaScript so that it can act as a Controller.  Nifty stuff!
 
+Note: As of Angular 1.3.0 this behavior has been removed and global constructors are not working anymore and will result in errors. [Changelog](https://github.com/angular/angular.js/blob/master/CHANGELOG.md#130-beta15-unbelievable-advancement-2014-07-11)
+
 Below's the final version:
 
 ```html


### PR DESCRIPTION
Hi guys,

I only did a quick read, but I really like the tutorial. It has a nice flow and builds up to concrete end result.

But maybe you should add a little note saying that global constructors are deprecated in angular 1.3.0. Just a little note will do I guess. Because when people test this in Plunkr's, .... they will eventually use 1.3.0, and probably pull there hair out finding what's wrong with their code.

I'm not saying you should put note's for every breaking change, but in this example you use a feature that's gone in an upcoming version. So maybe it's nice to alert readers for this one.

My note is not the best for your production documents and probably the changelog link is not needed. But you get the idea :)
